### PR TITLE
add gitattributes for line ending normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
This should preempt line ending issues for cross-platform contributions. See https://git-scm.com/docs/gitattributes for details about `.gitattributes`.