### PR TITLE
send system messages for updated MEMBERS data

### DIFF
--- a/board.html
+++ b/board.html
@@ -48,32 +48,7 @@
                     </div>
                     <div id="chat-inner" class="rounded">
                         <div id="chat-box" class="bordered">
-                            <div class="chat-message">:3</div>
-                            <div class="chat-message">:3</div>
-                            <div class="chat-message">:3</div>
-                            <div class="chat-message">:3</div>
-                            <div class="chat-message">:3</div>
-                            <div class="chat-message">:3</div>
-                            <div class="chat-message">:3</div>
-                            <div class="chat-message">:3</div>
-                            <div class="chat-message">:3</div>
-                            <div class="chat-message">:3</div>
-                            <div class="chat-message">:3</div>
-                            <div class="chat-message">:3</div>
-                            <div class="chat-message">:3</div>
-                            <div class="chat-message">:3</div>
-                            <div class="chat-message">:3</div>
-                            <div class="chat-message">:3</div>
-                            <div class="chat-message">:3</div>
-                            <div class="chat-message">:3</div>
-                            <div class="chat-message">:3</div>
-                            <div class="chat-message">:3</div>
-                            <div class="chat-message">:3</div>
-                            <div class="chat-message">:3</div>
-                            <div class="chat-message">:3</div>
-                            <div class="chat-message">:3</div>
-                            <div class="chat-message">:3</div>
-                            <div class="chat-message">:3</div>
+                            <div class="chat-message">Welcome to ByngoSink!</div>
                         </div>
                         <input id="chat-message-box" class="bordered">
                     </div>


### PR DESCRIPTION
Sends a message when:
- a person joins or leaves
- a new team is created
- a person joins a team or switches teams

It's a little janky right now, with redundant messages. Also I want to add a "user is spectating" message but I believe that requires websocket server changes to send down the spectator team id.

Here's a new room flow. In this example, slaur1 created the room but had to subsequently log in as slaur1 so there are two slaur1 users in the list
![image](https://github.com/ManicJamie/ByngoSink/assets/74829867/980cce70-7d9f-4820-bd20-88cd1dc4eb14)


Here's what it looks like when you join a finished game room:
![image](https://github.com/ManicJamie/ByngoSink/assets/74829867/c3c0f83c-c838-4fc1-8149-3588d6106b24)

